### PR TITLE
OS/X support using an AppleScript

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -4,12 +4,15 @@ import requests
 import urllib
 import time
 import os
+import sys
 import re
 import lyrics as minilyrics
 
-if os.name == "nt":
+if sys.platform == "win32":
     import pywintypes
     import win32gui
+elif sys.platform == "darwin":
+    import subprocess
 else:
     import subprocess
     import dbus
@@ -182,9 +185,16 @@ def getlyrics(songname, sync=False):
     return(lyrics, url, timed)
 
 def getwindowtitle():
-    if os.name == "nt":
+    if sys.platform== "win32":
         spotify = win32gui.FindWindow('SpotifyMainWindow', None)
         windowname = win32gui.GetWindowText(spotify)
+    elif sys.platform == "darwin":
+        windowname = ''
+        try:
+            command = "osascript getCurrentSong.AppleScript"
+            windowname = subprocess.check_output(["/bin/bash", "-c", command]).decode("utf-8")
+        except Exception:
+            pass
     else:
         windowname = ''
         session = dbus.SessionBus()

--- a/getCurrentSong.AppleScript
+++ b/getCurrentSong.AppleScript
@@ -1,0 +1,11 @@
+set currentlyPlayingTrack to getCurrentlyPlayingTrack()
+
+-- Method to get the currently playing track
+on getCurrentlyPlayingTrack()
+  tell application "Spotify"
+    set currentArtist to artist of current track as string
+    set currentTrack to name of current track as string
+  
+    return currentArtist & " - " & currentTrack
+  end tell
+end getCurrentlyPlayingTrack


### PR DESCRIPTION
Partially satisfies #19 

I have added an AppleScript that returns the currently playing song for the backend. I also modified some OS checking code since os.name cannot distinguish between Linux and OS/X. Works for me on El Capitan.
